### PR TITLE
[FEATURE] Add description field in ipauth

### DIFF
--- a/Configuration/TCA/Ip.php
+++ b/Configuration/TCA/Ip.php
@@ -6,10 +6,10 @@ if (!defined ('TYPO3_MODE')) {
 $TCA['tx_aoeipauth_domain_model_ip'] = array(
 	'ctrl' => $TCA['tx_aoeipauth_domain_model_ip']['ctrl'],
 	'interface' => array(
-		'showRecordFieldList' => 'hidden, ip',
+		'showRecordFieldList' => 'hidden, ip, description',
 	),
 	'types' => array(
-		'1' => array('showitem' => 'hidden;;1, ip'),
+		'1' => array('showitem' => 'hidden;;1, ip, description'),
 	),
 	'palettes' => array(
 		'1' => array('showitem' => ''),
@@ -59,6 +59,15 @@ $TCA['tx_aoeipauth_domain_model_ip'] = array(
 				'type' => 'input',
 				'size' => 60,
 				'eval' => 'trim,required'
+			),
+		),
+		'description' => array(
+			'exclude' => 0,
+			'label' => 'LLL:EXT:aoe_ipauth/Resources/Private/Language/locallang_db.xml:tx_aoeipauth_domain_model_ip.description',
+			'config' => array(
+				'type' => 'input',
+				'size' => 120,
+				'eval' => 'required'
 			),
 		),
 		'fe_user' => array(

--- a/Resources/Private/Language/locallang_csh_tx_aoeipauth_domain_model_ip.xml
+++ b/Resources/Private/Language/locallang_csh_tx_aoeipauth_domain_model_ip.xml
@@ -6,7 +6,7 @@
 		<csh_table>tx_aoeipauth_domain_model_ip</csh_table>
 	</meta>
 	<data type="array">
-	<languageKey index="default" type="array">
+		<languageKey index="default" type="array">
 			<label index="ip.description"><![CDATA[
 			Enter IP or IP range. Examples:<br />
 			- Simple IP: 192.168.2.4<br />

--- a/Resources/Private/Language/locallang_db.xml
+++ b/Resources/Private/Language/locallang_db.xml
@@ -9,6 +9,7 @@
 			<label index="tx_aoeipauth_domain_model_ip">IP</label>
 			<label index="tx_aoeipauth_domain_model_ip.hidden">Disable</label>
 			<label index="tx_aoeipauth_domain_model_ip.ip">IP/IP Range</label>
+			<label index="tx_aoeipauth_domain_model_ip.description">Description</label>
 
 			<label index="fe_users.tx_aoeipauth_ip">Auto-Login User when coming from following IP/range</label>
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -13,7 +13,7 @@ if (!defined('TYPO3_MODE')) {
 $TCA['tx_aoeipauth_domain_model_ip'] = array(
 	'ctrl' => array(
 		'title'	=> 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_db.xml:tx_aoeipauth_domain_model_ip',
-		'label' => 'ip',
+		'label' => 'description',
 		'tstamp' => 'tstamp',
 		'crdate' => 'crdate',
 		'cruser_id' => 'cruser_id',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -23,6 +23,7 @@ CREATE TABLE tx_aoeipauth_domain_model_ip (
 	fe_group int(11) unsigned DEFAULT '0' NOT NULL,
 	ip varchar(255) DEFAULT '' NOT NULL,
 	range_type tinyint(4) unsigned DEFAULT '0' NOT NULL,
+	description varchar(255) DEFAULT '' NOT NULL,
 
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
 	crdate int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Adds a description field to the IP range insertions and uses the description field as label. 

This is done to ease the editing of records later on, as the will be easier to identify. 