### PR TITLE
[BUG] #15 After installing Extension "Oops an error occurred"

### DIFF
--- a/Classes/Typo3/Service/Authentication.php
+++ b/Classes/Typo3/Service/Authentication.php
@@ -65,7 +65,9 @@ class Authentication extends \TYPO3\CMS\Sv\AbstractAuthenticationService {
 			if (empty($GLOBALS['TSFE']->sys_page)) {
 				$GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
 			}
-			$GLOBALS['TSFE']->getCompressedTCarray();
+			if (version_compare(TYPO3_version, '7.0.0', '<')) {
+				$GLOBALS['TSFE']->getCompressedTCarray();
+			}
 		}
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "issues": "https://github.com/AOEpeople/aoe_ipauth/issues"
   },
   "require": {
-      "typo3/cms-core": ">=6.2.1,<8.0"
+      "typo3/cms": ">=6.2.1,<8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8.0"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -37,6 +37,6 @@ if ('BE' === TYPO3_MODE) {
 		'os' => '',
 		'exec' => '',
 		'classFile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'Classes/Typo3/Service/Authentication.php',
-		'className' => '\AOE\AoeIpauth\Typo3\Service\Authentication',
+		'className' => 'AOE\AoeIpauth\Typo3\Service\Authentication',
 	)
 );


### PR DESCRIPTION
Solves issue #15 

As getCompressedTCarray has been removed. Full TCA is always loaded during bootstrap in FE, the methods are obsolete.
https://wiki.typo3.org/TYPO3_CMS_7.0#Breaking:_.2361785_-_getCompressedTCarray_and_includeTCA_from_TypoScriptFrontendController_removed