### PR TITLE
[COMPATIBILITY][V10] refactored aoe_ipauth extension for TYPO3 LTS v10.4

### DIFF
--- a/Classes/Typo3/Service/Authentication.php
+++ b/Classes/Typo3/Service/Authentication.php
@@ -26,7 +26,7 @@ namespace AOE\AoeIpauth\Typo3\Service;
  ***************************************************************/
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Sv\AbstractAuthenticationService;
+use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
 
 /**
  * Class Authentication
@@ -89,7 +89,6 @@ class Authentication extends AbstractAuthenticationService
 
         $clientIp = $this->authInfo['REMOTE_ADDR'];
         $ipAuthenticatedUsers = $this->findAllUsersByIpAuthentication($clientIp);
-
         if (empty($ipAuthenticatedUsers)) {
             return false;
         }

--- a/Configuration/TCA/tx_aoeipauth_domain_model_ip.php
+++ b/Configuration/TCA/tx_aoeipauth_domain_model_ip.php
@@ -44,7 +44,6 @@ $GLOBALS['TCA']['tx_aoeipauth_domain_model_ip'] = array(
         \TYPO3\CMS\Core\Utility\PathUtility::stripPathSitePrefix(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('aoe_ipauth')) . 'Resources/Public/Icons/tx_aoeipauth_domain_model_ip.png'
     ),
     'interface' => array(
-        'showRecordFieldList' => 'hidden, ip, description',
     ),
     'types' => array(
         '1' => array('showitem' => 'hidden;;1, ip, description'),

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "issues": "https://github.com/AOEpeople/aoe_ipauth/issues"
   },
   "require": {
-    "typo3/cms-core": ">=8.7.0,<10.0"
+    "typo3/cms-core": ">=8.7.0,<=10.4.99"
   },
   "require-dev": {
     "nimut/testing-framework": "^4.1",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-9.5.99',
+            'typo3' => '8.7.0-10.4.99',
         ],
         'conflicts' => [
         ],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,11 @@
 if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
+$_EXTKEY = 'aoe_ipauth';
+//var_dump($_EXTCONF);
+$backendConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('backend');
 
+//var_dump($backendConfiguration);
 if ('BE' === TYPO3_MODE) {
     // Do not show the IP records in the listing
     $allowedTablesTs = '
@@ -15,9 +19,11 @@ if ('BE' === TYPO3_MODE) {
     // Hooks
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][$_EXTKEY] = \AOE\AoeIpauth\Hooks\Tcemain::class;
 } elseif ('FE' === TYPO3_MODE) {
-    $extensionConfiguration = unserialize($_EXTCONF);
+    $extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        \TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
+    )->get($_EXTKEY);
     $GLOBALS['TYPO3_CONF_VARS']['SVCONF']['auth']['setup']['FE_fetchUserIfNoSession'] =
-        isset($extensionConfiguration['fetchFeUserIfNoSession']) ? $extensionConfiguration['fetchFeUserIfNoSession'] : 1;
+        isset($extensionConfiguration['fetchFeUserIfNoSession']) ? boolval($extensionConfiguration['fetchFeUserIfNoSession']) : 1;
     unset($extensionConfiguration);
 }
 


### PR DESCRIPTION
- changed version constraint in composer.json to 10.4.99
- changed version constraint in ext_emconf.php to 10.4.99
- refactored TYPO3\CMS\Sv\AbstractAuthenticationService in Authentication.php
- refactored $_EXTCONF due to deprecation in ext_localconf.php
- removed showRecordFieldList in TCA due to deprecation