### PR TITLE
[BUGFIX] Fetch all fe_user fields in findEntitiesWithIpAuthentication

### DIFF
--- a/Classes/Domain/Service/FeEntityService.php
+++ b/Classes/Domain/Service/FeEntityService.php
@@ -144,7 +144,7 @@ class FeEntityService implements \TYPO3\CMS\Core\SingletonInterface
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
         $queryBuilder->getRestrictions()->removeAll();
-        $entities = $queryBuilder->select('uid','pid')
+        $entities = $queryBuilder->select('*')
             ->from($table)
             ->where(
                 $queryBuilder->expr()->gt('tx_aoeipauth_ip', '0' . EnableFieldsUtility::enableFields($table))


### PR DESCRIPTION
The fe_users fields fetched in findEntitiesWithIpAuthentication are used in the authentication process, e.g. to determine user groups. If only uid and pid is fetched, the authentication service doesn't consider the user as authenticated even if a user session is generated. So the user is only correctly authenticated in the next request, e.g. after a redirect.